### PR TITLE
add ints benchmark

### DIFF
--- a/bench/ints.exs
+++ b/bench/ints.exs
@@ -1,0 +1,25 @@
+defmodule Bench do
+  def bind_int(stmt) do
+    XQLite.bind_int(stmt, 1, 10)
+  end
+
+  def bind_int_or_int64(stmt) do
+    XQLite.bind_int_or_int64(stmt, 1, 10)
+  end
+
+  def bind_int64(stmt) do
+    XQLite.bind_int64(stmt, 1, 10)
+  end
+end
+
+Benchee.run(
+  %{
+    "bind_int" => &Bench.bind_int/1,
+    "bind_int_or_int64" => &Bench.bind_int_or_int64/1,
+    "bind_int64" => &Bench.bind_int64/1
+  },
+  before_scenario: fn _input ->
+    db = XQLite.open(":memory:", [:readonly, :nomutex])
+    XQLite.prepare(db, "select ?")
+  end
+)

--- a/c_src/xqlite_nif.c
+++ b/c_src/xqlite_nif.c
@@ -302,6 +302,54 @@ xqlite_bind_integer(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 }
 
 static ERL_NIF_TERM
+xqlite_bind_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(argc == 3);
+
+    stmt_t *stmt;
+    if (!enif_get_resource(env, argv[0], stmt_type, (void **)&stmt))
+        return enif_make_badarg(env);
+
+    unsigned int idx;
+    if (!enif_get_uint(env, argv[1], &idx))
+        return enif_make_badarg(env);
+
+    int i;
+    if (!enif_get_int(env, argv[2], &i))
+        return enif_make_badarg(env);
+
+    int rc = sqlite3_bind_int(stmt->stmt, idx, i);
+    if (rc != SQLITE_OK)
+        return raise_sqlite3_error(env, rc, sqlite3_db_handle(stmt->stmt));
+
+    return am_ok;
+}
+
+static ERL_NIF_TERM
+xqlite_bind_int64(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(argc == 3);
+
+    stmt_t *stmt;
+    if (!enif_get_resource(env, argv[0], stmt_type, (void **)&stmt))
+        return enif_make_badarg(env);
+
+    unsigned int idx;
+    if (!enif_get_uint(env, argv[1], &idx))
+        return enif_make_badarg(env);
+
+    ErlNifSInt64 i64;
+    if (!enif_get_int64(env, argv[2], &i64))
+        return enif_make_badarg(env);
+
+    int rc = sqlite3_bind_int64(stmt->stmt, idx, i64);
+    if (rc != SQLITE_OK)
+        return raise_sqlite3_error(env, rc, sqlite3_db_handle(stmt->stmt));
+
+    return am_ok;
+}
+
+static ERL_NIF_TERM
 xqlite_bind_float(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     assert(argc == 3);
@@ -981,6 +1029,8 @@ static ErlNifFunc nif_funcs[] = {
     {"bind_text", 3, xqlite_bind_text},
     {"bind_blob", 3, xqlite_bind_blob},
     {"bind_integer", 3, xqlite_bind_integer},
+    {"bind_int", 3, xqlite_bind_int},
+    {"bind_int64", 3, xqlite_bind_int64},
     {"bind_float", 3, xqlite_bind_float},
     {"bind_null", 2, xqlite_bind_null},
     {"clear_bindings", 1, xqlite_clear_bindings},

--- a/lib/xqlite.ex
+++ b/lib/xqlite.ex
@@ -205,6 +205,17 @@ defmodule XQLite do
   @spec bind_integer(stmt, non_neg_integer, integer) :: :ok
   def bind_integer(_stmt, _index, _integer), do: :erlang.nif_error(:undef)
 
+  def bind_int(_stmt, _index, _integer), do: :erlang.nif_error(:undef)
+  def bind_int64(_stmt, _index, _integer), do: :erlang.nif_error(:undef)
+
+  def bind_int_or_int64(stmt, index, i) when i < 2_147_483_647 and i > -2_147_483_648 do
+    bind_int(stmt, index, i)
+  end
+
+  def bind_int_or_int64(stmt, index, integer) do
+    bind_int64(stmt, index, integer)
+  end
+
   @doc """
   Binds a float value to a prepared statement.
 


### PR DESCRIPTION
```console
$ env MIX_ENV=bench mix run bench/ints.exs
Operating System: macOS
CPU Information: Apple M2
Number of Available Cores: 8
Available memory: 8 GB
Elixir 1.17.1
Erlang 27.0
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 21 s

Benchmarking bind_int ...
Benchmarking bind_int64 ...
Benchmarking bind_int_or_int64 ...
Calculating statistics...
Formatting results...

Name                        ips        average  deviation         median         99th %
bind_int64              23.60 M       42.37 ns ±12219.95%          42 ns          83 ns
bind_int                23.27 M       42.98 ns ±12754.40%          42 ns          83 ns
bind_int_or_int64       23.14 M       43.22 ns ±13447.17%          42 ns          83 ns

Comparison:
bind_int64              23.60 M
bind_int                23.27 M - 1.01x slower +0.61 ns
bind_int_or_int64       23.14 M - 1.02x slower +0.85 ns
```